### PR TITLE
GREEN-31 Start using catracking in Matching Tool

### DIFF
--- a/catracking/ga/events.py
+++ b/catracking/ga/events.py
@@ -153,3 +153,11 @@ Application submission action.
 Label can be either `success` or `fail`
 """
 EVENT_ACTION_SUBMIT_APPLICATION = 'submit application'
+
+"""
+Category for all events related to matching tool
+"""
+
+EVENT_CATEGORY_MATCHING_TOOL = 'matching tool'
+
+EVENT_ACTION_BRAND_CALL_ME_NOW = 'brand call me now'

--- a/requirements/requirements-common.txt
+++ b/requirements/requirements-common.txt
@@ -1,3 +1,3 @@
-arrow>=0.10.0
+arrow==0.10.0
 requests>=2.14
 six

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import (
 
 setup(
     name='catracking',
-    version='0.1.6',
+    version='0.1.7',
     author='ConsumerAffairs',
     description='Tracking for ConsumerAffairs',
     url='https://github.com/ConsumerAffairs/catracking',


### PR DESCRIPTION
# [GREEN-31](https://consumeraffairs.atlassian.net/browse/GREEN-31)

## Description

This PR adds the initial `matching tool` category constant and initial `action`.
Also fixes the required version of `arrow` (both projects, `consumeraffairs` and `thewiz` use `0.10.0`)

## Acceptance Criteria

- [x] New constants are added
  